### PR TITLE
Ensure that hash.py is launched using Python

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ variable "path" {
 }
 
 data "external" "hash" {
-  program = ["${path.module}/hash.py"]
+  program = ["python", "${path.module}/hash.py"]
 
   query = {
     path = "${var.path}"


### PR DESCRIPTION
This avoids incompatibilities with Windows and any other systems which don't support the `/usr/bin/env python` shebang method of launching a .py file and doesn't change the behaviour on POSIX systems.