### PR TITLE
Fix deprecated warning in 0.12.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,15 @@
 variable "path" {
-  type = "string"
+  type = string
 }
 
 data "external" "hash" {
   program = ["python", "${path.module}/hash.py"]
 
   query = {
-    path = "${var.path}"
+    path = var.path
   }
 }
 
 output "result" {
-  value = "${data.external.hash.result["result"]}"
+  value = data.external.hash.result["result"]
 }


### PR DESCRIPTION
Currently, in Terraform 0.12.x, quoting a type constraint gives a deprecation warning:

```
Warning: Quoted type constraints are deprecated
  
 on .terraform/modules/foo.hash/main.tf line 2, in variable "path":
 2:   type = "string"
```

Not sure whether this is BC
